### PR TITLE
Updated to use installer for v3.3.2

### DIFF
--- a/pdfsam.install/pdfsam.install.nuspec
+++ b/pdfsam.install/pdfsam.install.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>pdfsam.install</id>
     <title>PDFsam Basic (Install)</title>
-    <version>3.3.1</version>
+    <version>3.3.2</version>
     <authors>Andrea Vacondio</authors>
     <owners>DUVERGIER Claude</owners>
     <summary>A simple tool designed to split and merge pdf files.</summary>
@@ -13,11 +13,10 @@
     <copyright></copyright>
     <licenseUrl>http://www.gnu.org/licenses/agpl-3.0.html</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <iconUrl>https://cdn.rawgit.com/torakiki/pdfsam/v3.3.1/pdfsam-community/src/main/resources/images/community/512x512.png</iconUrl>
+    <iconUrl>https://cdn.rawgit.com/torakiki/pdfsam/v3.3.2/pdfsam-community/src/main/resources/images/community/512x512.png</iconUrl>
     <dependencies>
       <dependency id="javaruntime" version="8.0.0" />
     </dependencies>
-    <releaseNotes>http://www.pdfsam.org/pdf-split-and-merge/new-release/pdfsam-basic-3-3-1-released/1755/</releaseNotes>
     <projectSourceUrl>https://github.com/torakiki/pdfsam</projectSourceUrl>
     <bugTrackerUrl>http://www.pdfsam.org/issue_tracker</bugTrackerUrl>
     <packageSourceUrl>https://github.com/C-Duv/chocolatey-pdfsam</packageSourceUrl>

--- a/pdfsam.install/tools/chocolateyInstall.ps1
+++ b/pdfsam.install/tools/chocolateyInstall.ps1
@@ -1,10 +1,10 @@
 $packageInstallArgs = @{
     packageName    = 'pdfsam.install'
     fileType       = 'msi'
-    url            = 'https://github.com/torakiki/pdfsam/releases/download/v3.3.1/pdfsam-v3.3.1.msi'
+    url            = 'https://github.com/torakiki/pdfsam/releases/download/v3.3.2/pdfsam-v3.3.2.msi'
     silentArgs     = '/quiet CHECK_FOR_UPDATES=false SKIPTHANKSPAGE=Yes'
     validExitCodes = @(0)
-    checksum       = '06240b9f573de43507c38dabce30ed7d4a1a7c30bc20785f8f89c3fe385cff0f'
+    checksum       = '7506cadd15a785c1ea5049a7cdf6ed23aa9446af2a5be1d2f6be1e5bc6b8c519'
     checksumType   = 'sha256'
 }
 

--- a/pdfsam/pdfsam.nuspec
+++ b/pdfsam/pdfsam.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>pdfsam</id>
     <title>PDFsam Basic</title>
-    <version>3.3.1</version>
+    <version>3.3.2</version>
     <authors>Andrea Vacondio</authors>
     <owners>DUVERGIER Claude</owners>
     <summary>A simple tool designed to split and merge pdf files.</summary>
@@ -13,11 +13,10 @@
     <copyright></copyright>
     <licenseUrl>http://www.gnu.org/licenses/agpl-3.0.html</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <iconUrl>https://cdn.rawgit.com/torakiki/pdfsam/v3.3.1/pdfsam-community/src/main/resources/images/community/512x512.png</iconUrl>
+    <iconUrl>https://cdn.rawgit.com/torakiki/pdfsam/v3.3.2/pdfsam-community/src/main/resources/images/community/512x512.png</iconUrl>
     <dependencies>
-      <dependency id="pdfsam.install" version="[3.3.1]" />
+      <dependency id="pdfsam.install" version="[3.3.2]" />
     </dependencies>
-    <releaseNotes>http://www.pdfsam.org/pdf-split-and-merge/new-release/pdfsam-basic-3-3-1-released/1755/</releaseNotes>
     <projectSourceUrl>https://github.com/torakiki/pdfsam</projectSourceUrl>
     <bugTrackerUrl>http://www.pdfsam.org/issue_tracker</bugTrackerUrl>
     <packageSourceUrl>https://github.com/C-Duv/chocolatey-pdfsam</packageSourceUrl>


### PR DESCRIPTION
This commit makes the package install PDFsam Basic v3.3.2.